### PR TITLE
Pin sae_vis to previous working version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ eindex = {git = "https://github.com/callummcdougall/eindex.git"}
 datasets = "^2.17.1"
 babe = "^0.0.7"
 nltk = "^3.8.1"
-sae-vis = {git = "https://github.com/callummcdougall/sae_vis.git"}
+sae-vis = {git = "https://github.com/callummcdougall/sae_vis.git", rev = "4bcef489b644dd3357b1975f3245d534f6f0d2e0"}
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
The sae_vis library changed the names and imports of the library in a recent commit. This PR pins the sae_vis dependency to an earlier version of the library until we can update our code to work with the new changes.