### PR TITLE
FIX: Don't check wandb assert if not using wandb

### DIFF
--- a/sae_analysis/dashboard_runner.py
+++ b/sae_analysis/dashboard_runner.py
@@ -364,19 +364,20 @@ class DashboardRunner:
                             step=test_idx,
                         )
 
-        # when done zip the folder
-        shutil.make_archive(self.dashboard_folder, "zip", self.dashboard_folder)
+        if self.use_wandb:
+            # when done zip the folder
+            shutil.make_archive(self.dashboard_folder, "zip", self.dashboard_folder)
 
-        # then upload the zip as an artifact
-        artifact = wandb.Artifact("dashboard", type="zipped_feature_dashboards")
-        artifact.add_file(f"{self.dashboard_folder}.zip")
-        assert run is not None  # keep pyright happy
-        run.log_artifact(artifact)
+            # then upload the zip as an artifact
+            artifact = wandb.Artifact("dashboard", type="zipped_feature_dashboards")
+            artifact.add_file(f"{self.dashboard_folder}.zip")
+            assert run is not None  # keep pyright happy
+            run.log_artifact(artifact)
 
-        # terminate the run
-        run.finish()
+            # terminate the run
+            run.finish()
 
-        # delete the dashboard folder
-        shutil.rmtree(self.dashboard_folder)
+            # delete the dashboard folder
+            shutil.rmtree(self.dashboard_folder)
 
         return


### PR DESCRIPTION
Issue:
DashboardRunner fails when use_wandb=False

Cause:
DashboardRunner does an assert at the end to check if "run" (a wandb variable) is not None, even if use_wandb is set to False. This will always fail when use_wandb is False because "run" isn't initialized.

Fix:
Add check for use_wandb before doing this assert and other code for uploading to wandb.

Possible modifications / other considerations:
Should we still zip up the folder and/or delete it?
