### PR TITLE
adding a contribution guide to docs

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -36,6 +36,7 @@ jobs:
         run: poetry install --no-root
 
       - name: Deploy website
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: poetry run mkdocs gh-deploy

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -1,0 +1,46 @@
+# Contributing
+
+Contributions are welcome! To get setup for development, follow the instructions below.
+
+## Setup
+
+Make sure you have [poetry](https://python-poetry.org/) installed, clone the repository, and install dependencies with:
+
+```bash
+poetry install
+```
+
+## Testing, Linting, and Formatting
+
+This project uses [pytest](https://docs.pytest.org/en/stable/) for testing, [flake8](https://flake8.pycqa.org/en/latest/) for linting, [pyright](https://github.com/microsoft/pyright) for type-checking, and [black](https://black.readthedocs.io/en/stable/) and [isort](https://pycqa.github.io/isort/) for formatting.
+
+If you add new code, it would be greatly appreciated if you could add tests in the `tests/unit` directory. You can run the tests with:
+
+```bash
+make unit-test
+```
+
+Before commiting, make sure you format the code with:
+
+```bash
+make format
+```
+
+Finally, run all CI checks locally with:
+
+```bash
+make check-ci
+```
+
+If these pass, you're good to go! Open a pull request with your changes.
+
+## Documentation
+
+This project uses [mkdocs](https://www.mkdocs.org/) for documentation. You can see the docs locally with:
+
+```bash
+make docs-serve
+```
+If you make changes to code which requires updating documentation, it would be greatly appreciated if you could update the docs as well.
+
+

--- a/makefile
+++ b/makefile
@@ -19,3 +19,11 @@ unit-test:
 
 acceptance-test:
 	poetry run pytest -v --cov=sae_training/ --cov-report=term-missing --cov-branch tests/acceptance
+
+check-ci:
+	make check-format
+	make check-type
+	make unit-test
+
+docs-serve:
+	poetry run mkdocs serve


### PR DESCRIPTION
This PR adds a contribution guide page to the docs, outlining how to get set up for development and what to run to make sure your code is up to par before opening a PR. This PR also adds some more makefile helpers to facilitate easier checking of code by contributors.

Some things to note:
- I didn't include anything about autodocs or docstring comments in the guide, since I don't think mkdocs supports autodoc. If we have a preferred docstring style we should consider adding a linting rule for it.
- I didn't add a demo `.vscode/settings.json` config, in case we change to use `ruff` for litning/formatting, as that would require a different vscode setup. If we want to stick with what we have, I'll add that to the docs too.

The rendered docs page is shown below
![127 0 0 1_8000_about_contributing_](https://github.com/jbloomAus/mats_sae_training/assets/200725/2ac79792-4bae-4545-a087-91b96521451f)
