### PR TITLE
attempting to fix docs deploy

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -39,4 +39,4 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: poetry run mkdocs gh-deploy
+        run: poetry run mkdocs gh-deploy --force


### PR DESCRIPTION
I'm not 100% sure this is the issue with the docs deploy, but I think the problem is that the `gh-pages` branch isn't stricly upsteam of the attempts to push to `gh-pages`, thus causes the deploy to get rejected. Hopefully adding `--force` to the CI step should fix the issue.