### PR TITLE
fixing config typing

### DIFF
--- a/sae_training/activations_store.py
+++ b/sae_training/activations_store.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import os
-from typing import Any, Iterator, cast
+from typing import Any, Iterator, Literal, TypeVar, cast
 
 import torch
 from datasets import (
@@ -12,6 +14,11 @@ from datasets import (
 from torch.utils.data import DataLoader
 from transformer_lens import HookedTransformer
 
+from sae_training.config import (
+    CacheActivationsRunnerConfig,
+    LanguageModelSAERunnerConfig,
+)
+
 HfDataset = DatasetDict | Dataset | IterableDatasetDict | IterableDataset
 
 
@@ -21,18 +28,85 @@ class ActivationsStore:
     while training SAEs.
     """
 
-    def __init__(
-        self,
-        cfg: Any,
+    model: HookedTransformer
+    dataset: HfDataset
+    cached_activations_path: str | None
+    tokens_column: Literal["tokens", "input_ids", "text"]
+    hook_point_head_index: int | None
+
+    @classmethod
+    def from_config(
+        cls,
         model: HookedTransformer,
+        cfg: LanguageModelSAERunnerConfig | CacheActivationsRunnerConfig,
         dataset: HfDataset | None = None,
         create_dataloader: bool = True,
-    ):
-        self.cfg = cfg
-        self.model = model
-        self.dataset = dataset or load_dataset(
-            cfg.dataset_path, split="train", streaming=True
+    ) -> "ActivationsStore":
+        cached_activations_path = cfg.cached_activations_path
+        # set cached_activations_path to None if we're not using cached activations
+        if (
+            isinstance(cfg, LanguageModelSAERunnerConfig)
+            and not cfg.use_cached_activations
+        ):
+            cached_activations_path = None
+        return cls(
+            model=model,
+            dataset=dataset or cfg.dataset_path,
+            hook_point=cfg.hook_point,
+            hook_point_layers=listify(cfg.hook_point_layer),
+            hook_point_head_index=cfg.hook_point_head_index,
+            context_size=cfg.context_size,
+            d_in=cfg.d_in,
+            n_batches_in_buffer=cfg.n_batches_in_buffer,
+            total_training_tokens=cfg.total_training_tokens,
+            store_batch_size=cfg.store_batch_size,
+            train_batch_size=cfg.train_batch_size,
+            prepend_bos=cfg.prepend_bos,
+            device=cfg.device,
+            dtype=cfg.dtype,
+            cached_activations_path=cached_activations_path,
+            create_dataloader=create_dataloader,
         )
+
+    def __init__(
+        self,
+        model: HookedTransformer,
+        dataset: HfDataset | str,
+        hook_point: str,
+        hook_point_layers: list[int],
+        hook_point_head_index: int | None,
+        context_size: int,
+        d_in: int,
+        n_batches_in_buffer: int,
+        total_training_tokens: int,
+        store_batch_size: int,
+        train_batch_size: int,
+        prepend_bos: bool,
+        device: str | torch.device,
+        dtype: torch.dtype,
+        cached_activations_path: str | None = None,
+        create_dataloader: bool = True,
+    ):
+        self.model = model
+        self.dataset = (
+            load_dataset(dataset, split="train", streaming=True)
+            if isinstance(dataset, str)
+            else dataset
+        )
+        self.hook_point = hook_point
+        self.hook_point_layers = hook_point_layers
+        self.hook_point_head_index = hook_point_head_index
+        self.context_size = context_size
+        self.d_in = d_in
+        self.n_batches_in_buffer = n_batches_in_buffer
+        self.total_training_tokens = total_training_tokens
+        self.store_batch_size = store_batch_size
+        self.train_batch_size = train_batch_size
+        self.prepend_bos = prepend_bos
+        self.device = device
+        self.dtype = dtype
+        self.cached_activations_path = cached_activations_path
+
         self.iterable_dataset = iter(self.dataset)
 
         # Check if dataset is tokenized
@@ -40,13 +114,13 @@ class ActivationsStore:
 
         # check if it's tokenized
         if "tokens" in dataset_sample.keys():
-            self.cfg.is_dataset_tokenized = True
+            self.is_dataset_tokenized = True
             self.tokens_column = "tokens"
         elif "input_ids" in dataset_sample.keys():
-            self.cfg.is_dataset_tokenized = True
+            self.is_dataset_tokenized = True
             self.tokens_column = "input_ids"
         elif "text" in dataset_sample.keys():
-            self.cfg.is_dataset_tokenized = False
+            self.is_dataset_tokenized = False
             self.tokens_column = "text"
         else:
             raise ValueError(
@@ -54,32 +128,32 @@ class ActivationsStore:
             )
         self.iterable_dataset = iter(self.dataset)  # Reset iterator after checking
 
-        if self.cfg.use_cached_activations:  # EDIT: load from multi-layer acts
-            assert self.cfg.cached_activations_path is not None  # keep pyright happy
+        if cached_activations_path is not None:  # EDIT: load from multi-layer acts
+            assert self.cached_activations_path is not None  # keep pyright happy
             # Sanity check: does the cache directory exist?
             assert os.path.exists(
-                self.cfg.cached_activations_path
-            ), f"Cache directory {self.cfg.cached_activations_path} does not exist. Consider double-checking your dataset, model, and hook names."
+                self.cached_activations_path
+            ), f"Cache directory {self.cached_activations_path} does not exist. Consider double-checking your dataset, model, and hook names."
 
             self.next_cache_idx = 0  # which file to open next
             self.next_idx_within_buffer = 0  # where to start reading from in that file
 
             # Check that we have enough data on disk
-            first_buffer = torch.load(f"{self.cfg.cached_activations_path}/0.pt")
+            first_buffer = torch.load(f"{self.cached_activations_path}/0.pt")
             buffer_size_on_disk = first_buffer.shape[0]
-            n_buffers_on_disk = len(os.listdir(self.cfg.cached_activations_path))
+            n_buffers_on_disk = len(os.listdir(self.cached_activations_path))
             # Note: we're assuming all files have the same number of tokens
             # (which seems reasonable imo since that's what our script does)
             n_activations_on_disk = buffer_size_on_disk * n_buffers_on_disk
             assert (
-                n_activations_on_disk > self.cfg.total_training_tokens
-            ), f"Only {n_activations_on_disk/1e6:.1f}M activations on disk, but cfg.total_training_tokens is {self.cfg.total_training_tokens/1e6:.1f}M."
+                n_activations_on_disk > self.total_training_tokens
+            ), f"Only {n_activations_on_disk/1e6:.1f}M activations on disk, but total_training_tokens is {self.total_training_tokens/1e6:.1f}M."
 
             # TODO add support for "mixed loading" (ie use cache until you run out, then switch over to streaming from HF)
 
         if create_dataloader:
             # fill buffer half a buffer, so we can mix it with a new buffer
-            self.storage_buffer = self.get_buffer(self.cfg.n_batches_in_buffer // 2)
+            self.storage_buffer = self.get_buffer(self.n_batches_in_buffer // 2)
             self.dataloader = self.get_data_loader()
 
     def get_batch_tokens(self):
@@ -87,9 +161,9 @@ class ActivationsStore:
         Streams a batch of tokens from a dataset.
         """
 
-        batch_size = self.cfg.store_batch_size
-        context_size = self.cfg.context_size
-        device = self.cfg.device
+        batch_size = self.store_batch_size
+        context_size = self.context_size
+        device = self.device
 
         batch_tokens = torch.zeros(
             size=(0, context_size), device=device, dtype=torch.long, requires_grad=False
@@ -124,7 +198,7 @@ class ActivationsStore:
                     token_len -= space_left
 
                     # only add BOS if it's not already the first token
-                    if self.cfg.prepend_bos:
+                    if self.prepend_bos:
                         bos_token_id_tensor = torch.tensor(
                             [self.model.tokenizer.bos_token_id],
                             device=tokens.device,
@@ -160,23 +234,19 @@ class ActivationsStore:
 
         d_in may result from a concatenated head dimension.
         """
-        layers = (
-            self.cfg.hook_point_layer
-            if isinstance(self.cfg.hook_point_layer, list)
-            else [self.cfg.hook_point_layer]
-        )
-        act_names = [self.cfg.hook_point.format(layer=layer) for layer in layers]
+        layers = self.hook_point_layers
+        act_names = [self.hook_point.format(layer=layer) for layer in layers]
         hook_point_max_layer = max(layers)
         layerwise_activations = self.model.run_with_cache(
             batch_tokens,
             names_filter=act_names,
             stop_at_layer=hook_point_max_layer + 1,
-            prepend_bos=self.cfg.prepend_bos,
+            prepend_bos=self.prepend_bos,
         )[1]
         activations_list = [layerwise_activations[act_name] for act_name in act_names]
-        if self.cfg.hook_point_head_index is not None:
+        if self.hook_point_head_index is not None:
             activations_list = [
-                act[:, :, self.cfg.hook_point_head_index] for act in activations_list
+                act[:, :, self.hook_point_head_index] for act in activations_list
             ]
         elif activations_list[0].ndim > 3:  # if we have a head dimension
             # flatten the head dimension
@@ -190,31 +260,27 @@ class ActivationsStore:
         return stacked_activations
 
     def get_buffer(self, n_batches_in_buffer: int):
-        context_size = self.cfg.context_size
-        batch_size = self.cfg.store_batch_size
-        d_in = self.cfg.d_in
+        context_size = self.context_size
+        batch_size = self.store_batch_size
+        d_in = self.d_in
         total_size = batch_size * n_batches_in_buffer
-        num_layers = (
-            len(self.cfg.hook_point_layer)
-            if isinstance(self.cfg.hook_point_layer, list)
-            else 1
-        )  # Number of hook points or layers
+        num_layers = len(self.hook_point_layers)  # Number of hook points or layers
 
-        if self.cfg.use_cached_activations:
+        if self.cached_activations_path is not None:
             # Load the activations from disk
             buffer_size = total_size * context_size
             # Initialize an empty tensor with an additional dimension for layers
             new_buffer = torch.zeros(
                 (buffer_size, num_layers, d_in),
-                dtype=self.cfg.dtype,
-                device=self.cfg.device,
+                dtype=self.dtype,
+                device=self.device,
             )
             n_tokens_filled = 0
 
             # Assume activations for different layers are stored separately and need to be combined
             while n_tokens_filled < buffer_size:
                 if not os.path.exists(
-                    f"{self.cfg.cached_activations_path}/{self.next_cache_idx}.pt"
+                    f"{self.cached_activations_path}/{self.next_cache_idx}.pt"
                 ):
                     print(
                         "\n\nWarning: Ran out of cached activation files earlier than expected."
@@ -222,7 +288,7 @@ class ActivationsStore:
                     print(
                         f"Expected to have {buffer_size} activations, but only found {n_tokens_filled}."
                     )
-                    if buffer_size % self.cfg.total_training_tokens != 0:
+                    if buffer_size % self.total_training_tokens != 0:
                         print(
                             "This might just be a rounding error — your batch_size * n_batches_in_buffer * context_size is not divisible by your total_training_tokens"
                         )
@@ -232,7 +298,7 @@ class ActivationsStore:
                     return new_buffer
 
                 activations = torch.load(
-                    f"{self.cfg.cached_activations_path}/{self.next_cache_idx}.pt"
+                    f"{self.cached_activations_path}/{self.next_cache_idx}.pt"
                 )
                 taking_subset_of_file = False
                 if n_tokens_filled + activations.shape[0] > buffer_size:
@@ -257,8 +323,8 @@ class ActivationsStore:
         # Initialize empty tensor buffer of the maximum required size with an additional dimension for layers
         new_buffer = torch.zeros(
             (total_size, context_size, num_layers, d_in),
-            dtype=self.cfg.dtype,
-            device=self.cfg.device,
+            dtype=self.dtype,
+            device=self.device,
         )
 
         for refill_batch_idx_start in refill_iterator:
@@ -286,11 +352,11 @@ class ActivationsStore:
 
         """
 
-        batch_size = self.cfg.train_batch_size
+        batch_size = self.train_batch_size
 
         # 1. # create new buffer by mixing stored and new buffer
         mixing_buffer = torch.cat(
-            [self.get_buffer(self.cfg.n_batches_in_buffer // 2), self.storage_buffer],
+            [self.get_buffer(self.n_batches_in_buffer // 2), self.storage_buffer],
             dim=0,
         )
 
@@ -325,14 +391,14 @@ class ActivationsStore:
             return next(self.dataloader)
 
     def _get_next_dataset_tokens(self) -> torch.Tensor:
-        device = self.cfg.device
-        if not self.cfg.is_dataset_tokenized:
+        device = self.device
+        if not self.is_dataset_tokenized:
             s = next(self.iterable_dataset)[self.tokens_column]
             tokens = self.model.to_tokens(
                 s,
                 truncate=True,
                 move_to_device=True,
-                prepend_bos=self.cfg.prepend_bos,
+                prepend_bos=self.prepend_bos,
             ).squeeze(0)
             assert (
                 len(tokens.shape) == 1
@@ -345,8 +411,17 @@ class ActivationsStore:
                 requires_grad=False,
             )
             if (
-                not self.cfg.prepend_bos
+                not self.prepend_bos
                 and tokens[0] == self.model.tokenizer.bos_token_id  # type: ignore
             ):
                 tokens = tokens[1:]
         return tokens
+
+
+T = TypeVar("T")
+
+
+def listify(x: T | list[T]) -> list[T]:
+    if isinstance(x, list):
+        return x
+    return [x]

--- a/sae_training/cache_activations_runner.py
+++ b/sae_training/cache_activations_runner.py
@@ -13,16 +13,21 @@ from sae_training.utils import shuffle_activations_pairwise
 def cache_activations_runner(cfg: CacheActivationsRunnerConfig):
     model = HookedTransformer.from_pretrained(cfg.model_name)
     model.to(cfg.device)
-    activations_store = ActivationsStore(cfg, model, create_dataloader=False)
+    activations_store = ActivationsStore.from_config(
+        model,
+        cfg,
+        create_dataloader=False,
+    )
 
     # if the activations directory exists and has files in it, raise an exception
-    if os.path.exists(activations_store.cfg.cached_activations_path):
-        if len(os.listdir(activations_store.cfg.cached_activations_path)) > 0:
+    assert activations_store.cached_activations_path is not None
+    if os.path.exists(activations_store.cached_activations_path):
+        if len(os.listdir(activations_store.cached_activations_path)) > 0:
             raise Exception(
-                f"Activations directory ({activations_store.cfg.cached_activations_path}) is not empty. Please delete it or specify a different path. Exiting the script to prevent accidental deletion of files."
+                f"Activations directory ({activations_store.cached_activations_path}) is not empty. Please delete it or specify a different path. Exiting the script to prevent accidental deletion of files."
             )
     else:
-        os.makedirs(activations_store.cfg.cached_activations_path)
+        os.makedirs(activations_store.cached_activations_path)
 
     print(f"Started caching {cfg.total_training_tokens} activations")
     tokens_per_buffer = (
@@ -32,7 +37,7 @@ def cache_activations_runner(cfg: CacheActivationsRunnerConfig):
     # for i in tqdm(range(n_buffers), desc="Caching activations"):
     for i in range(n_buffers):
         buffer = activations_store.get_buffer(cfg.n_batches_in_buffer)
-        torch.save(buffer, f"{activations_store.cfg.cached_activations_path}/{i}.pt")
+        torch.save(buffer, f"{activations_store.cached_activations_path}/{i}.pt")
         del buffer
 
         if i % cfg.shuffle_every_n_buffers == 0 and i > 0:
@@ -41,14 +46,14 @@ def cache_activations_runner(cfg: CacheActivationsRunnerConfig):
             # Do random pairwise shuffling between the last shuffle_every_n_buffers buffers
             for _ in range(cfg.n_shuffles_with_last_section):
                 shuffle_activations_pairwise(
-                    activations_store.cfg.cached_activations_path,
+                    activations_store.cached_activations_path,
                     buffer_idx_range=(i - cfg.shuffle_every_n_buffers, i),
                 )
 
             # Do more random pairwise shuffling between all the buffers
             for _ in range(cfg.n_shuffles_in_entire_dir):
                 shuffle_activations_pairwise(
-                    activations_store.cfg.cached_activations_path,
+                    activations_store.cached_activations_path,
                     buffer_idx_range=(0, i),
                 )
 
@@ -56,6 +61,6 @@ def cache_activations_runner(cfg: CacheActivationsRunnerConfig):
     if n_buffers > 1:
         for _ in tqdm(range(cfg.n_shuffles_final), desc="Final shuffling"):
             shuffle_activations_pairwise(
-                activations_store.cfg.cached_activations_path,
+                activations_store.cached_activations_path,
                 buffer_idx_range=(0, n_buffers),
             )

--- a/sae_training/evals.py
+++ b/sae_training/evals.py
@@ -21,7 +21,7 @@ def run_evals(
     suffix: str = "",
 ) -> Mapping[str, Any]:
     hook_point = sparse_autoencoder.cfg.hook_point
-    hook_point_layer = sparse_autoencoder.cfg.hook_point_layer
+    hook_point_layer = sparse_autoencoder.hook_point_layer
     hook_point_head_index = sparse_autoencoder.cfg.hook_point_head_index
 
     ### Evals

--- a/sae_training/utils.py
+++ b/sae_training/utils.py
@@ -4,6 +4,7 @@ import torch
 from transformer_lens import HookedTransformer
 
 from sae_training.activations_store import ActivationsStore
+from sae_training.config import LanguageModelSAERunnerConfig
 from sae_training.sae_group import SAEGroup
 from sae_training.sparse_autoencoder import SparseAutoencoder
 
@@ -78,7 +79,7 @@ class LMSparseAutoencoderSessionloader:
 
         return model
 
-    def initialize_sparse_autoencoder(self, cfg: Any):
+    def initialize_sparse_autoencoder(self, cfg: LanguageModelSAERunnerConfig):
         """
         Initializes a sparse autoencoder group, which contains multiple sparse autoencoders
         """
@@ -87,14 +88,16 @@ class LMSparseAutoencoderSessionloader:
 
         return sparse_autoencoder
 
-    def get_activations_loader(self, cfg: Any, model: HookedTransformer):
+    def get_activations_loader(
+        self, cfg: LanguageModelSAERunnerConfig, model: HookedTransformer
+    ):
         """
         Loads a DataLoaderBuffer for the activations of a language model.
         """
 
-        activations_loader = ActivationsStore(
-            cfg,
+        activations_loader = ActivationsStore.from_config(
             model,
+            cfg,
         )
 
         return activations_loader

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -23,7 +23,6 @@ def build_sae_cfg(**kwargs: Any) -> LanguageModelSAERunnerConfig:
         use_cached_activations=False,
         d_in=64,
         expansion_factor=2,
-        d_sae=64 * 2,
         l1_coefficient=2e-3,
         lp_norm=1,
         lr=2e-4,

--- a/tests/unit/test_sae_group.py
+++ b/tests/unit/test_sae_group.py
@@ -1,0 +1,44 @@
+from sae_training.sae_group import SAEGroup
+from tests.unit.helpers import build_sae_cfg
+
+
+def test_SAEGroup_initializes_all_permutations_of_list_params():
+    cfg = build_sae_cfg(
+        d_in=5,
+        lr=[0.01, 0.001],
+        expansion_factor=[2, 4],
+    )
+    sae_group = SAEGroup(cfg)
+    assert len(sae_group) == 4
+    lr_sae_combos = [(ae.cfg.lr, ae.cfg.d_sae) for ae in sae_group]
+    assert (0.01, 10) in lr_sae_combos
+    assert (0.01, 20) in lr_sae_combos
+    assert (0.001, 10) in lr_sae_combos
+    assert (0.001, 20) in lr_sae_combos
+
+
+def test_SAEGroup_replaces_layer_with_actual_layer():
+    cfg = build_sae_cfg(
+        hook_point="blocks.{layer}.attn.hook_q",
+        hook_point_layer=5,
+    )
+    sae_group = SAEGroup(cfg)
+    assert len(sae_group) == 1
+    assert sae_group.autoencoders[0].cfg.hook_point == "blocks.5.attn.hook_q"
+
+
+def test_SAEGroup_train_and_eval():
+    cfg = build_sae_cfg(
+        lr=[0.01, 0.001],
+        expansion_factor=[2, 4],
+    )
+    sae_group = SAEGroup(cfg)
+    sae_group.train()
+    for sae in sae_group:
+        assert sae.training is True
+    sae_group.eval()
+    for sae in sae_group:
+        assert sae.training is False
+    sae_group.train()
+    for sae in sae_group:
+        assert sae.training is True

--- a/tests/unit/test_sparse_autoencoder.py
+++ b/tests/unit/test_sparse_autoencoder.py
@@ -228,7 +228,7 @@ def test_SparseAutoencoder_remove_gradient_parallel_to_decoder_directions() -> N
     grad_delta = orig_grad - sae.W_dec.grad
     assert torch.nn.functional.cosine_similarity(
         sae.W_dec.detach(), grad_delta, dim=1
-    ).abs() == pytest.approx(1.0, abs=1e-5)
+    ).abs() == pytest.approx(1.0, abs=1e-3)
 
 
 def test_SparseAutoencoder_get_name_returns_correct_name_from_cfg_vals() -> None:

--- a/tests/unit/test_train_sae_on_language_model.py
+++ b/tests/unit/test_train_sae_on_language_model.py
@@ -34,6 +34,7 @@ def build_train_ctx(
     Factory helper to build a default SAETrainContext object.
     """
     assert sae.cfg.d_sae is not None
+    assert not isinstance(sae.cfg.lr, list)
     optimizer = torch.optim.Adam(sae.parameters(), lr=sae.cfg.lr)
     return SAETrainContext(
         act_freq_scores=(
@@ -323,7 +324,7 @@ def test_train_sae_group_on_language_model__runs_and_outputs_look_reasonable(
     )
     # just a tiny datast which will run quickly
     dataset = Dataset.from_list([{"text": "hello world"}] * 1000)
-    activation_store = ActivationsStore(cfg, model=ts_model, dataset=dataset)
+    activation_store = ActivationsStore.from_config(ts_model, cfg, dataset=dataset)
     sae_group = SAEGroup(cfg)
     res = train_sae_group_on_language_model(
         model=ts_model,


### PR DESCRIPTION
This PR adds optional list typing for config params that can take a list of values for SAEGroup construction, and enables proper config typing for `ActivationsStore` and `SAEGroup` classes.

In #44, I originally tried to remove the config from `SAEGroup` entirely to avoid having the same config class passed to both SAE and SAEGroup, since SAE can't have any list values, but SAEGroup can. I think I was overthinking this, and just explicitly setting the SAEGroup fields that can be lists as optional lists, and adding some assertions in SAE construction that these cfg values are not lists seems to solve the problem. I also set some of these types on the SAE class itself so we can read the values from the SAE object instead of from `sae.cfg` to avoid needing to keep asserting that things aren't lists.

Enabling typing for the `ActivationsStore` cfg revealed that the cache runner config was missing some required params that ActivationsStore needs, so this PR moves those shared params into the base `RunnerConfig` class.

fixes #44