### PR TITLE
removing unused eindex depencency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ nbformat = "^5.9.2"
 ipykernel = "^6.29.2"
 matplotlib = "^3.8.3"
 matplotlib-inline = "^0.1.6"
-eindex = {git = "https://github.com/callummcdougall/eindex.git"}
 datasets = "^2.17.1"
 babe = "^0.0.7"
 nltk = "^3.8.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ black==23.11.0
 pytest==7.4.3
 pytest-cov==4.1.0
 pre-commit==3.6.0
-git+https://github.com/callummcdougall/eindex.git


### PR DESCRIPTION
CI is [currently broken](https://github.com/jbloomAus/mats_sae_training/actions/runs/8509749352/job/23305929241?pr=62) because the `eindex` dependency just changed its name to `eindex-callum` (see [commit](https://github.com/callummcdougall/eindex/commit/695dbb9e9a2a3224c28485fb6e0b8b92c274dcbd)), so our dependencies are now incorrect and we can't install our project. It looks like this dependency is never used in our project anyway, so this PR just removes it as a dependency entirely. 