### PR TITLE
adding lr_decay_steps and refactoring get_scheduler

### DIFF
--- a/sae_training/config.py
+++ b/sae_training/config.py
@@ -64,9 +64,10 @@ class LanguageModelSAERunnerConfig(RunnerConfig):
     lp_norm: float = 1
     lr: float = 3e-4
     lr_scheduler_name: str = (
-        "constantwithwarmup"  # constant, constantwithwarmup, linearwarmupdecay, cosineannealing, cosineannealingwarmup
+        "constant"  # constant, cosineannealing, cosineannealingwarmrestarts
     )
     lr_warm_up_steps: int = 500
+    lr_decay_steps: int = 0
     train_batch_size: int = 4096
 
     # Resampling protocol args

--- a/sae_training/train_sae_on_language_model.py
+++ b/sae_training/train_sae_on_language_model.py
@@ -218,6 +218,7 @@ def _build_train_context(
     optimizer = Adam(sae.parameters(), lr=sae.cfg.lr)
     scheduler = get_scheduler(
         sae.cfg.lr_scheduler_name,
+        lr=sae.cfg.lr,
         optimizer=optimizer,
         warm_up_steps=sae.cfg.lr_warm_up_steps,
         training_steps=total_training_steps,

--- a/tests/unit/test_train_sae_on_language_model.py
+++ b/tests/unit/test_train_sae_on_language_model.py
@@ -46,7 +46,9 @@ def build_train_ctx(
         ),
         n_frac_active_tokens=n_frac_active_tokens,
         optimizer=optimizer,
-        scheduler=get_scheduler(None, optimizer=optimizer),
+        scheduler=get_scheduler(
+            "constant", lr=sae.cfg.lr, optimizer=optimizer, training_steps=1000
+        ),
     )
 
 


### PR DESCRIPTION
This PR adds a `lr_decay_steps` config option which will linearly decay learning rate to 0 at the end of training. This PR simplifies the `get_scheduler` function by removing `constantwithwarmup`, `linearwarmupdecay`, and `cosineannealingwarmup` options. Instead, any scheduler can now have a linear warmup and linear decay by setting the `lr_warm_up_steps` and `lr_decay_steps`.

This also required changing some of the options passed to `get_scheduler`. This function now takes in `lr` as well, since there's a discrepancy with how torch's cosine annealing scheduler works compared to how the other schedulers. Specifically, it seems that torch's cosine annealing actually sets the final LR to the value specified by eta_min, but the other schedulers don't know what the current learning rate is and instead can only set the LR to a portion of its original value. In order to address this discrepancy, we need to know the LR so we can calculate what the expected end LR should be as a portion of the base LR. This also has a nice side-effect of meaning that the `lr_end` value is the actual final LR, instead of a portion of the original LR which felt unexpected.

closes #61 