### PR TITLE
fix: removing paths-ignore from action to avoid blocking releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,19 +5,9 @@ on:
     branches:
       - main
       - clean_up_repo
-    paths-ignore:
-      - '.devcontainer/**'
-      - '.vscode/**'
-      - '.gitignore'
-      - '*.md'
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '.devcontainer/**'
-      - '.vscode/**'
-      - '.gitignore'
-      - '*.md'
   # Allow this workflow to be called from other workflows
   workflow_call:
     inputs:


### PR DESCRIPTION
This PR removes the `paths-ignore` key from the build workflow, as this may unintentionally block releases from running. Semantic-release will fail if when it comes time to publish a relase, the published commit is no longer the head commit in the repo. This is to avoid situations where an earlier commit might get a later version number than later commit if they both are merged at roughly the same time.

However, if the most recent commit is just a change to the README.md for example,  the `paths-ignore` can cause semantic-release to fail. If, due to the README.md change, it is no longer the most recent commit to the repo, semantic release will bail out assuming that the most recent CI run will pull in the changes and publish,  but due to the `paths-ignore`, CI never gets run and thus the change never gets deployed.